### PR TITLE
Bump version to 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.spacehq</groupId>
     <artifactId>opennbt</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>OpenNBT</name>


### PR DESCRIPTION
Why?

Due to recent changes, you would need to force maven to redownload version 1.0 to use them.

Bumping the versions allows the parent project to simply use 1.1 and have no issues with clients updating OpenNBT to latest.