### PR TITLE
Allow empty ListTag for conversion and adding elements to empty lists

### DIFF
--- a/src/main/java/com/github/steveice10/opennbt/conversion/builtin/ListTagConverter.java
+++ b/src/main/java/com/github/steveice10/opennbt/conversion/builtin/ListTagConverter.java
@@ -25,10 +25,6 @@ public class ListTagConverter implements TagConverter<ListTag, List> {
 
     @Override
     public ListTag convert(String name, List value) {
-        if(value.isEmpty()) {
-            throw new IllegalArgumentException("Cannot convert ListTag with size of 0.");
-        }
-
         List<Tag> tags = new ArrayList<Tag>();
         for(Object o : value) {
             tags.add(ConverterRegistry.convertToTag("", o));

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/ListTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/ListTag.java
@@ -94,12 +94,17 @@ public class ListTag extends Tag implements Iterable<Tag> {
     }
 
     /**
-     * Adds a tag to this list tag.
+     * Adds a tag to this list tag, if the list is empty it will use the element as the list type.
      *
      * @param tag Tag to add.
      * @return If the list was changed as a result.
      */
     public boolean add(Tag tag) {
+        // If empty list, use this as tag type
+        if(this.value.size() == 0) {
+            this.type = tag.getClass();
+        }
+
         if(tag.getClass() != this.type) {
             throw new IllegalArgumentException("Tag type cannot differ from ListTag type.");
         }


### PR DESCRIPTION
Currently, empty ListTags are not useful for modification as you cannot add elements to the empty list (because the tag type will differ).

This proposes the following:
- Allow empty lists to inherit the first element added (this is what Minecraft does)
- Allow empty lists when converting between NBT -> Maps (makes it more useful when dealing with proper NBT data)

I'm welcome to any feedback etc :) 